### PR TITLE
Migrate documentation to the vert.x mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
 
   <parent>
     <groupId>io.vertx</groupId>
-    <artifactId>vertx-parent</artifactId>
-    <version>8</version>
+    <artifactId>vertx-ext-parent</artifactId>
+    <version>19</version>
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
@@ -18,6 +18,8 @@
   <properties>
     <stack.version>3.2.0</stack.version>
     <ignite.version>1.5.0.final</ignite.version>
+
+    <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>
 
   <dependencyManagement>
@@ -57,6 +59,31 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codetrans</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-groovy</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-ruby</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-js</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/src/main/asciidoc/java/index.ad
+++ b/src/main/asciidoc/java/index.ad
@@ -1,0 +1,134 @@
+= Apache Ignite Cluster Manager for Vert.x
+
+This is a cluster manager implementation for Vert.x that uses http://ignite.apache.org/index.html[Apache Ignite].
+
+In Vert.x a cluster manager is used for various functions including:
+
+* Discovery and group membership of Vert.x nodes in a cluster
+* Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus
+addresses)
+* Distributed Map support
+* Distributed Locks
+*  Distributed Counters
+
+Cluster managers *do not* handle the event bus inter-node transport, this is done directly by Vert.x with TCP
+connections.
+
+Vert.x cluster manager is a pluggable component, so you can pick the one you want, or the one that is the most
+adapted to your environment. So you can replace default Vert.x cluster manager by this implementation.
+
+== Using this cluster manager
+
+If the jar is on your classpath then Vert.x will automatically detect this and use it as the cluster manager.
+Please make sure you don’t have any other cluster managers on your classpath or Vert.x might choose the wrong one.
+
+Alternatively, you can configure the following system property to instruct vert.x to use this cluster manager:
+`-Dvertx.clusterManagerFactory=io.vertx.spi.cluster.ignite.IgniteClusterManager`
+
+### Using Vert.x from command line
+
+`vertx-ignite-3.2.0.jar` should be in the `lib` directory of the Vert.x installation.
+
+### Using Vert.x in Maven or Gradle project
+
+Add a dependency to the artifact.
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-ignite</artifactId>
+  <version>3.2.0</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-ignite:3.2.0'
+----
+
+### Programmatically specifying cluster manager
+
+You can also specify the cluster manager programmatically. In order to do this just specify it on the options
+when you are creating your Vert.x instance, for example:
+
+[source,java]
+----
+ClusterManager clusterManager = new IgniteClusterManager();
+
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+Vertx.clusteredVertx(options, res -> {
+  if (res.succeeded()) {
+    Vertx vertx = res.result();
+  } else {
+    // failed!
+  }
+});
+----
+
+== Configuring cluster manager
+
+=== Using configuration file
+
+The cluster manager is configured by a file `default-ignite.xml` which is packaged inside the jar.
+
+If you want to override this configuration you can provide `ignite.xml` file on your classpath and this will be
+used instead.
+
+The xml file is a Ignite configuration file and is described in details in
+https://apacheignite.readme.io/docs[Apache Ignite documentation].
+
+### Configuring programmatically
+
+You can also specify configuration programmatically:
+
+[source,java]
+----
+IgniteConfiguration cfg = new IgniteConfiguration();
+// Configuration code (omitted)
+
+ClusterManager clusterManager = new IgniteClusterManager(cfg);
+
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+Vertx.clusteredVertx(options, res -> {
+  if (res.succeeded()) {
+    Vertx vertx = res.result();
+  } else {
+    // failed!
+  }
+});
+----
+
+=== Discovery and network transport configuration
+
+The default configuration uses `TcpDiscoveryMulticastIpFinder` so you must have multicast enabled on your network.
+For cases when multicast is disabled `TcpDiscoveryVmIpFinder` should be used with pre-configured list of IP addresses.
+Please see http://apacheignite.readme.io/docs/cluster-config[Cluster Configuration] section
+at Apache Ignite documentation for details.
+
+== Trouble shooting clustering
+
+If the default multicast configuration is not working here are some common causes:
+
+=== Multicast not enabled on the machine.
+
+When using `UDP`, IP multicasting is required, on some systems, multicast route(s) need to be added to
+the routing table otherwise, the default route will be used
+
+Note that some systems don't consult the routing table for IP multicast routing, only for unicast routing
+
+MacOS example:
+
+----
+# Adds a multicast route for 224.0.0.1-231.255.255.254
+sudo route add -net 224.0.0.0/5 127.0.0.1
+
+# Adds a multicast route for 232.0.0.1-239.255.255.254
+sudo route add -net 232.0.0.0/5 192.168.1.3
+----
+
+Please google for more information.

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -1,0 +1,43 @@
+package examples;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.spi.cluster.ignite.IgniteClusterManager;
+import org.apache.ignite.configuration.IgniteConfiguration;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class Examples {
+
+  public void example1() {
+    ClusterManager clusterManager = new IgniteClusterManager();
+
+    VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+    Vertx.clusteredVertx(options, res -> {
+      if (res.succeeded()) {
+        Vertx vertx = res.result();
+      } else {
+        // failed!
+      }
+    });
+  }
+
+  public void example2() {
+    IgniteConfiguration cfg = new IgniteConfiguration();
+    // Configuration code (omitted)
+
+    ClusterManager clusterManager = new IgniteClusterManager(cfg);
+
+    VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+    Vertx.clusteredVertx(options, res -> {
+      if (res.succeeded()) {
+        Vertx vertx = res.result();
+      } else {
+        // failed!
+      }
+    });
+  }
+
+}

--- a/src/main/java/examples/package-info.java
+++ b/src/main/java/examples/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 The original author or authors
+ * ---------------------------------
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+@Source
+package examples;
+
+import io.vertx.docgen.Source;

--- a/src/main/java/io/vertx/spi/cluster/ignite/package-info.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/package-info.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2015 The original author or authors
+ * ---------------------------------
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+/**
+ * = Apache Ignite Cluster Manager for Vert.x
+ *
+ * This is a cluster manager implementation for Vert.x that uses http://ignite.apache.org/index.html[Apache Ignite].
+ *
+ * In Vert.x a cluster manager is used for various functions including:
+ *
+ * * Discovery and group membership of Vert.x nodes in a cluster
+ * * Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus
+ * addresses)
+ * * Distributed Map support
+ * * Distributed Locks
+ * *  Distributed Counters
+ *
+ * Cluster managers *do not* handle the event bus inter-node transport, this is done directly by Vert.x with TCP
+ * connections.
+ *
+ * Vert.x cluster manager is a pluggable component, so you can pick the one you want, or the one that is the most
+ * adapted to your environment. So you can replace default Vert.x cluster manager by this implementation.
+ *
+ * == Using this cluster manager
+ *
+ * If the jar is on your classpath then Vert.x will automatically detect this and use it as the cluster manager.
+ * Please make sure you don’t have any other cluster managers on your classpath or Vert.x might choose the wrong one.
+ *
+ * Alternatively, you can configure the following system property to instruct vert.x to use this cluster manager:
+ * `-Dvertx.clusterManagerFactory=io.vertx.spi.cluster.ignite.IgniteClusterManager`
+ *
+ * ### Using Vert.x from command line
+ *
+ * `vertx-ignite-${maven.version}.jar` should be in the `lib` directory of the Vert.x installation.
+ *
+ * ### Using Vert.x in Maven or Gradle project
+ *
+ * Add a dependency to the artifact.
+ *
+ * * Maven (in your `pom.xml`):
+ *
+ * [source,xml,subs="+attributes"]
+ * ----
+ * <dependency>
+ *   <groupId>${maven.groupId}</groupId>
+ *   <artifactId>${maven.artifactId}</artifactId>
+ *   <version>${maven.version}</version>
+ * </dependency>
+ * ----
+ *
+ * * Gradle (in your `build.gradle` file):
+ *
+ * [source,groovy,subs="+attributes"]
+ * ----
+ * compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
+ * ----
+ *
+ * ### Programmatically specifying cluster manager
+ *
+ * You can also specify the cluster manager programmatically. In order to do this just specify it on the options
+ * when you are creating your Vert.x instance, for example:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.Examples#example1()}
+ * ----
+ *
+ * == Configuring cluster manager
+ *
+ * === Using configuration file
+ *
+ * The cluster manager is configured by a file `default-ignite.xml` which is packaged inside the jar.
+ *
+ * If you want to override this configuration you can provide `ignite.xml` file on your classpath and this will be
+ * used instead.
+ *
+ * The xml file is a Ignite configuration file and is described in details in
+ * https://apacheignite.readme.io/docs[Apache Ignite documentation].
+ *
+ * ### Configuring programmatically
+ *
+ * You can also specify configuration programmatically:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.Examples#example2()}
+ * ----
+ *
+ * === Discovery and network transport configuration
+ *
+ * The default configuration uses `TcpDiscoveryMulticastIpFinder` so you must have multicast enabled on your network.
+ * For cases when multicast is disabled `TcpDiscoveryVmIpFinder` should be used with pre-configured list of IP addresses.
+ * Please see http://apacheignite.readme.io/docs/cluster-config[Cluster Configuration] section
+ * at Apache Ignite documentation for details.
+ *
+ * == Trouble shooting clustering
+ *
+ * If the default multicast configuration is not working here are some common causes:
+ *
+ * === Multicast not enabled on the machine.
+ *
+ * By default the cluster manager is using `TcpDiscoveryMulticastIpFinder`, so IP multicasting is required,
+ * on some systems, multicast route(s) need to be added to the routing table otherwise, the default route will be used.
+ *
+ * Note that some systems don't consult the routing table for IP multicast routing, only for unicast routing
+ *
+ * MacOS example:
+ *
+ * ----
+ * # Adds a multicast route for 224.0.0.1-231.255.255.254
+ * sudo route add -net 224.0.0.0/5 127.0.0.1
+ *
+ * # Adds a multicast route for 232.0.0.1-239.255.255.254
+ * sudo route add -net 232.0.0.0/5 192.168.1.3
+ * ----
+ *
+ * Please google for more information.
+ *
+ */
+@Document(fileName = "index.ad")
+package io.vertx.spi.cluster.ignite;
+
+import io.vertx.docgen.Document;


### PR DESCRIPTION
Fixes #2.

The `src/main/asciidoc` file is generated on build.
To generate the HTML output, execute:

`mvn clean package -DskipTests -Ddocs`

Output is in  `target/docs/vertx-ignite/java/index.html`

How does it works for official components:
1. the .ad is generated and packaged in a -docs artifacts
2. the vert.x stack project retrieves this artifact and assemble the .ad files
3. the vert.x web site get the assembled documentation and generates the HTML web site using special stylesheets
